### PR TITLE
fix: fallback to ids when fetching orgunit data

### DIFF
--- a/packages/prediction-app/src/hooks/useOrgUnitsById.ts
+++ b/packages/prediction-app/src/hooks/useOrgUnitsById.ts
@@ -1,11 +1,10 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Query, useQueryClient } from '@tanstack/react-query'
 import { useApiDataQuery } from '../utils/useApiDataQuery'
 
 type OrganisationUnit = {
     id: string
     displayName: string
-    path: string
 }
 
 type OrgUnitResult = {
@@ -57,6 +56,29 @@ export const useOrgUnitsById = (orgUnitIds: string[]) => {
             },
         },
         enabled: orgUnitIds.length > 0,
+        select: useCallback(
+            (data: OrgUnitResult) => {
+                // some orgUnits were not found (eg data in Chap not in DHIS2)
+                // fallback to id...
+                if (data.organisationUnits.length !== orgUnitIds.length) {
+                    const fetchedOrgUnitIdsSet = new Set(
+                        data.organisationUnits.map((ou) => ou.id)
+                    )
+                    const missingUnits = orgUnitIds
+                        .filter((id) => !fetchedOrgUnitIdsSet.has(id))
+                        .map((id) => ({
+                            id,
+                            displayName: id, // fallback to id as displayName
+                        }))
+                    return {
+                        organisationUnits:
+                            data.organisationUnits.concat(missingUnits),
+                    }
+                }
+                return data
+            },
+            [orgUnitIds]
+        ),
         cacheTime: Infinity,
         staleTime: Infinity,
     })


### PR DESCRIPTION
This should help fix issues with the orgunit-selector if the DHIS2 instance doesn't have the ids from chap. 