### PR TITLE
fix(orgunits): sorted units and clear all button [skip release]

### DIFF
--- a/packages/prediction-app/src/components/OrganisationUnitsSelect/OrganisationUnitMultiSelect.tsx
+++ b/packages/prediction-app/src/components/OrganisationUnitsSelect/OrganisationUnitMultiSelect.tsx
@@ -38,13 +38,15 @@ const OrganisationUnitMultiSelect = ({
     const [pendingSelectedOrgUnits, setPendingSelectedOrgUnits] = useState<
         string[] | null
     >(null)
+
     const resolvedSelected =
         pendingSelectedOrgUnits !== null ? pendingSelectedOrgUnits : selected
 
     // Multiselect will crash if selected contains items that are not in available
     // this can happen when loading, thus we add the selected items to the available list
-    const { orgUnits } = useMemo(() => {
+    const { orgUnits, selectedOrgUnitIds } = useMemo(() => {
         const orgUnitsMap = new Map(available.map((o) => [o.id, o]))
+        const selectedSet = new Set(resolvedSelected)
         resolvedSelected.forEach((s) => {
             if (!orgUnitsMap.get(s)) {
                 orgUnitsMap.set(s, {
@@ -54,18 +56,26 @@ const OrganisationUnitMultiSelect = ({
             }
         })
 
+        const orgUnits = Array.from(orgUnitsMap.values())
+        const selectedOrgUnitIds = orgUnits.flatMap((ou) =>
+            selectedSet.has(ou.id) ? [ou.id] : []
+        )
         return {
-            orgUnits: Array.from(orgUnitsMap.values()),
+            orgUnits,
+            // use these IDs for the selected prop, so we use ordering from available
+            selectedOrgUnitIds: selectedOrgUnitIds,
         }
     }, [available, resolvedSelected])
 
     return (
         <MultiSelect
             prefix={i18n.t('Organisation Units')}
-            selected={resolvedSelected}
+            selected={selectedOrgUnitIds}
             disabled={available.length < 1}
             filterable
             filterPlaceholder={i18n.t('Search organisation units')}
+            clearable={true}
+            clearText={i18n.t('Clear all organisation units')}
             onChange={({ selected }, event) => {
                 const isChipDeletion = event.type === 'click'
                 if (isChipDeletion) {

--- a/packages/prediction-app/src/features/evaluation-compare/EvaluationCompare.tsx
+++ b/packages/prediction-app/src/features/evaluation-compare/EvaluationCompare.tsx
@@ -26,7 +26,7 @@ import { useNavigate } from 'react-router-dom'
 const MAX_SELECTED_ORG_UNITS = 10
 
 export const EvaluationCompare = () => {
-    const navigate = useNavigate();
+    const navigate = useNavigate()
     const {
         selectedEvaluations,
         baseEvaluation,
@@ -58,13 +58,15 @@ export const EvaluationCompare = () => {
         const dataForSplitPeriod = combined.viewData
             .filter((v) => v.splitPoint === selectedSplitPeriod)
             .flatMap((v) =>
-                v.evaluation.map((e) => ({
-                    ...e,
-                    orgUnitName:
-                        orgUnitsData?.organisationUnits?.find(
-                            (ou) => ou.id === e.orgUnitId
-                        )?.displayName ?? e.orgUnitId,
-                }))
+                v.evaluation
+                    .map((e) => ({
+                        ...e,
+                        orgUnitName:
+                            orgUnitsData?.organisationUnits?.find(
+                                (ou) => ou.id === e.orgUnitId
+                            )?.displayName ?? e.orgUnitId,
+                    }))
+                    .sort((a, b) => a.orgUnitName.localeCompare(b.orgUnitName))
             )
         const periods = dataForSplitPeriod[0]?.models[0].data.periods ?? []
         return { dataForSplitPeriod, periods }

--- a/packages/prediction-app/src/features/evaluation-compare/EvaluationCompare.tsx
+++ b/packages/prediction-app/src/features/evaluation-compare/EvaluationCompare.tsx
@@ -66,8 +66,8 @@ export const EvaluationCompare = () => {
                                 (ou) => ou.id === e.orgUnitId
                             )?.displayName ?? e.orgUnitId,
                     }))
-                    .sort((a, b) => a.orgUnitName.localeCompare(b.orgUnitName))
-            )
+                )
+                .sort((a, b) => a.orgUnitName.localeCompare(b.orgUnitName))
         const periods = dataForSplitPeriod[0]?.models[0].data.periods ?? []
         return { dataForSplitPeriod, periods }
     }, [combined.viewData, selectedSplitPeriod, orgUnitsData])

--- a/packages/prediction-app/src/hooks/useOrgUnitsById.ts
+++ b/packages/prediction-app/src/hooks/useOrgUnitsById.ts
@@ -53,6 +53,7 @@ export const useOrgUnitsById = (orgUnitIds: string[]) => {
                 paging: false,
                 fields: ['id', 'displayName'],
                 filter: `id:in:[${orgUnitIds.join(',')}]`,
+                order: 'displayName:asc'
             },
         },
         enabled: orgUnitIds.length > 0,


### PR DESCRIPTION
Use the sort-order from available units, so that the units are sorted according to API. Also add `clearable` which adds a button to clear all units. 