### PR TITLE
fix(sidebar): collapse sidebar in new evaluation [skip release]

### DIFF
--- a/packages/prediction-app/src/App.tsx
+++ b/packages/prediction-app/src/App.tsx
@@ -28,6 +28,8 @@ import { EvaluationComparePage } from './pages/EvaluationCompare'
 
 export type RouteHandle = {
     fullWidth?: boolean
+    /* whether to automatically collapse the sidebar when route is active*/
+    collapseSidebar?: boolean
 }
 
 const router = createHashRouter([
@@ -70,6 +72,9 @@ const router = createHashRouter([
                             {
                                 path: 'new',
                                 element: <NewEvaluationPage />,
+                                handle: {
+                                    collapseSidebar: true,
+                                } satisfies RouteHandle,
                             },
                         ],
                     },

--- a/packages/prediction-app/src/components/layout/Layout.tsx
+++ b/packages/prediction-app/src/components/layout/Layout.tsx
@@ -1,8 +1,9 @@
-import cx from 'classnames'
 import React from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useMatches } from 'react-router-dom'
 import { Sidebar } from '../sidebar'
 import css from './Layout.module.css'
+import { RouteHandle } from '../../App'
+import cx from 'classnames'
 
 interface BaseLayoutProps {
     children: React.ReactNode
@@ -21,15 +22,17 @@ export const BaseLayout = ({ children, sidebar }: BaseLayoutProps) => {
 export const SidebarLayout = ({
     children,
     hideSidebar,
+    collapseSidebar = false,
 }: {
     children: React.ReactNode
     hideSidebar?: boolean
+    collapseSidebar?: boolean
 }) => {
     return (
         <BaseLayout
             sidebar={
                 <Sidebar
-                    hideSidebar={hideSidebar}
+                    hideSidebar={collapseSidebar || hideSidebar}
                     className={cx(css.sidebar, { [css.hide]: hideSidebar })}
                 />
             }
@@ -40,8 +43,11 @@ export const SidebarLayout = ({
 }
 
 export const Layout = () => {
+    const collapseSidebar = useMatches().some(
+        (match) => (match.handle as RouteHandle)?.collapseSidebar
+    )
     return (
-        <SidebarLayout>
+        <SidebarLayout collapseSidebar={collapseSidebar}>
             <Outlet />
         </SidebarLayout>
     )

--- a/packages/prediction-app/src/components/sidebar/Sidebar.tsx
+++ b/packages/prediction-app/src/components/sidebar/Sidebar.tsx
@@ -4,14 +4,10 @@ import cx from 'classnames'
 import React, { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import styles from './Sidebar.module.css'
-import {
-    Sidenav, SidenavItems,
-    SidenavLink,
-    SidenavParent
-} from './sidenav'
+import { Sidenav, SidenavItems, SidenavLink, SidenavParent } from './sidenav'
 
 type LinkItem = {
-    to: string,
+    to: string
     label: string
 }
 interface SidebarNavLinkProps {
@@ -63,7 +59,6 @@ const SidebarParent = ({
     )
 }
 
-
 export const Sidebar = ({
     className,
     hideSidebar,
@@ -71,11 +66,16 @@ export const Sidebar = ({
     className?: string
     hideSidebar?: boolean
 }) => {
+    const collapsedExternally = React.useRef<boolean>(false)
     const [collapsed, setCollapsed] = useState(false)
 
     useEffect(() => {
-        if (hideSidebar !== undefined) {
-            setCollapsed(hideSidebar)
+        // only react if explicitly defined
+        // however, do react if it has been changed externally
+        // eg. so that it reopen when navigating away from a collapsed route
+        if (hideSidebar !== undefined || collapsedExternally.current) {
+            setCollapsed(!!hideSidebar)
+            collapsedExternally.current = !!hideSidebar
         }
     }, [hideSidebar])
 
@@ -121,6 +121,5 @@ export const Sidebar = ({
         </aside>
     )
 }
-
 
 export default Sidebar


### PR DESCRIPTION

- Automatically collapse the sidebar when navigating to a route with `collapseSidebar: true`
- Reopen sidebar when navigating away from such a route
- Currently only `New Evaluation`-route has this defined

https://github.com/user-attachments/assets/5dc43758-0569-4b68-873e-ae3870913fab

